### PR TITLE
Create ISSUE_TEMPLATE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,41 @@
+<!--- 
+Thanks for contributing your input! Instructions are in comments, like this 
+-->
+
+_please edit this template before submitting a new issue_
+
+<!--- 
+Title: Provide a general summary of your feature / question / issue in the title above. 
+-->
+
+<!---
+Tags: please select one or more relevant tags
+--->
+
+### Description
+<!--- 
+Is there something you want to do? Is this a bug? Feature request? Discussion? 
+  * Question: ask away!
+  * New feature / analysis : 
+  * Bug: what were you trying to do? What did you expect to happen? What happened? 
+-->
+
+<!--- 
+### Details
+How would this change help? (you, the project, the user community? 
+How would it be used? 
+      Are there any examples (existing software / utilities)? Please provide links, screenshots, etc-->
+
+### Completion Criteria   
+
+<!--- How will we know when this is done?
+please use boxes like
+for a bug:
+* [ ] Now I can [topic of question / bug]
+for a discussion:
+* [ ] Discuss and develop requirements docs; create issues for next steps
+for a new feature
+* [ ] create algorithm
+* [ ] write test
+* [ ] add to pipeline
+--->


### PR DESCRIPTION
Added Issue template from computing-pipeline repository

Perhaps should be customized for reference-data repository (e.g. help users know what they should ask under reference-data vs. computing-pipeline vs. other repositories).